### PR TITLE
Mark html-webpack-plugin v4 as supported

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "webpack": "^4.11.1"
   },
   "peerDependencies": {
-    "html-webpack-plugin": "^3.0.0"
+    "html-webpack-plugin": "^3.0.0 || ^4.0.0"
   },
   "dependencies": {
     "lodash": "^4.17.15"


### PR DESCRIPTION
As far as I understand, html-webpack-plugin v4 [is already officially supported](https://github.com/Runjuu/html-inline-css-webpack-plugin/commit/60f0c15c55ea1c6ad68a8f20d3a4087930b91c19). 