### PR TITLE
chore: enable using the plugin without `.default`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ yarn add html-inline-css-webpack-plugin -D
 ```js
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const HTMLInlineCSSWebpackPlugin = require("html-inline-css-webpack-plugin").default;
+const HTMLInlineCSSWebpackPlugin = require("html-inline-css-webpack-plugin");
 
 module.exports = {
   plugins: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,6 @@ import {
 
 const isHTMLWebpackPluginV4 = 'getHooks' in HTMLWebpackPlugin
 
-export default (isHTMLWebpackPluginV4
+export = isHTMLWebpackPluginV4
   ? PluginForHtmlWebpackPluginV4
-  : PluginForHtmlWebpackPluginV3)
+  : PluginForHtmlWebpackPluginV3


### PR DESCRIPTION
Enable using this plugin without property access like `.default`.

```js
// const HTMLInlineCSSWebpackPlugin = require("html-inline-css-webpack-plugin").default;
const HTMLInlineCSSWebpackPlugin = require("html-inline-css-webpack-plugin");
```