### PR TITLE
Move tslib from devDeps to deps in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "husky": "^1.3.1",
     "lint-staged": "^8.1.0",
     "prettier": "^1.15.3",
-    "tslib": "^1.9.3",
     "tslint": "^5.12.1",
     "tslint-eslint-rules": "^5.4.0",
     "tslint-sonarts": "^1.8.0",
@@ -62,6 +61,7 @@
     "html-webpack-plugin": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "dependencies": {
-    "lodash": "^4.17.15"
+    "lodash": "^4.17.15",
+    "tslib": "^1.9.3"
   }
 }


### PR DESCRIPTION
Hello,
Builded files depend on `tslib` so it should be in `dependencies`.

Currently when you try to use this plugin with `html-webpack-plugin@3.2.0` it breaks with `Error: Cannot find module 'tslib'` error, because `npm install` doesn't install `devDependencies`.

`html-webpack-plugin` added `tslib` as its own dependency since 4.0.0 version so there the problem does not arise (that covers the problem).

