### PR TITLE
fix bug: Compatible with the condition that the html-webpack-plugin inject option value is false

### DIFF
--- a/src/core/base-plugin.ts
+++ b/src/core/base-plugin.ts
@@ -97,9 +97,7 @@ export class BasePlugin {
     }
 
     if (html.indexOf(this.replaceConfig.target) === -1) {
-      throw new Error(
-        `Can not inject css style into "${htmlFileName}", as there is not replace target "${this.replaceConfig.target}"`,
-      )
+      return replaceValues.join('');
     }
 
     return html.replace(this.replaceConfig.target, replaceValues.join(''))


### PR DESCRIPTION
example:

```javascript
plugins: [
     new HtmlWebpackPlugin({
            template: path.resolve(__dirname, '../../assets/pages/user/index.html'),
            inject: false,
        }),
        new HTMLInlineCSSWebpackPlugin()
]
````

before: 
```bash
ERROR in   Error: Can not inject css style into "index.html", as there is not replace target "</head>"
  
  - base-plugin.js:86 PluginForHtmlWebpackPluginV4.BasePlugin.addStyle
    [www-soa]/[html-inline-css-webpack-plugin]/build/core/base-plugin.js:86:23
  
  - v4.js:60 
    [www-soa]/[html-inline-css-webpack-plugin]/build/core/v4.js:60:39
  
  - Array.forEach
  
  - v4.js:59 PluginForHtmlWebpackPluginV4.process
    [www-soa]/[html-inline-css-webpack-plugin]/build/core/v4.js:59:27
  
  - v4.js:78 
    [www-soa]/[html-inline-css-webpack-plugin]/build/core/v4.js:78:27
  
  
  - new Promise
  
  
  - Hook.js:22 Hook.PROMISE_DELEGATE [as _promise]
    [www-soa]/[tapable]/lib/Hook.js:22:14
  
  - index.js:347 injectedHtmlPromise.then
    [www-soa]/[html-webpack-plugin]/index.js:347:72
  
  - next_tick.js:68 process._tickCallback
    internal/process/next_tick.js:68:7
```

after:
<style>something...</style>

